### PR TITLE
Add automated slot creation via Slot Creator helper workflow

### DIFF
--- a/.cursor/rules/n8n-sdlc.md
+++ b/.cursor/rules/n8n-sdlc.md
@@ -60,12 +60,22 @@ If these files don't exist, run the **Getting Started** or **Import Project** sk
 
 Because MCP cannot create workflows in the correct folder:
 
-1. **User creates empty workflows** manually in n8n UI within the project folder
-2. **AI pulls these workflows** to discover their IDs
+### Automated Path (Slot Creator configured)
+1. **AI calls the Slot Creator webhook** to bulk-create empty workflows and transfer them to the project folder
+2. **AI auto-assigns slots** (empty slots are fungible)
 3. **AI claims the slots** by updating `n8n-sdlc/config/id-mappings.json`
 4. **AI updates the workflows** via MCP with actual content
 
-This is the ONLY way to get workflows into the correct n8n folder.
+The Slot Creator is configured via `slotCreator.webhookUrl` in `project.json`. See `n8n-sdlc/helpers/README.md`.
+
+### Manual Path (No Slot Creator)
+1. **User creates empty workflows** manually in n8n UI within the project folder
+2. **AI pulls these workflows** to discover their IDs
+3. **AI auto-assigns slots** and confirms the mapping with the user
+4. **AI claims the slots** by updating `n8n-sdlc/config/id-mappings.json`
+5. **AI updates the workflows** via MCP with actual content
+
+Both paths are the ONLY way to get workflows into the correct n8n folder.
 
 ## Project Scoping (MCP Lock to One Project)
 
@@ -299,5 +309,6 @@ project/
 | Promote DEV->PROD | Yes - show changes + "confirm" | Both configs + all in-project refs mapped | Auto commit+push + offer PR |
 | Seed DEV from PROD | No | project.json, id-mappings.json | Auto commit+push |
 | Import project | User guides discovery | project.json | Auto commit+push (initial) |
-| Reserve slots | User selects from list | project.json | Auto commit+push |
+| Reserve slots (automated) | API key + confirm mapping | project.json, slotCreator | Auto commit+push |
+| Reserve slots (manual) | User creates slots + confirm mapping | project.json | Auto commit+push |
 | Get started (wizard) | User answers questions | None (creates them) | Sets up git config |

--- a/.cursor/skills/n8n-sdlc-getting-started/SKILL.md
+++ b/.cursor/skills/n8n-sdlc-getting-started/SKILL.md
@@ -155,7 +155,49 @@ Do you have a git repo set up for this n8n project?
 1. Set `git.enabled` to `false` in config
 2. All git sync steps in other skills will be skipped silently
 
-### Question 5: .gitignore
+### Question 5: Slot Creator (Optional)
+
+```
+Would you like to set up the Slot Creator for automated workflow creation?
+
+The Slot Creator is a helper workflow that runs in your n8n instance.
+It lets the AI agent automatically create empty workflow slots in your
+project folder, instead of you creating them manually in the UI.
+
+1. Yes -- I'll walk you through importing and configuring it
+2. Skip -- I'll set this up later (or use manual slot creation)
+```
+
+**Option 1 -- Yes:**
+1. Tell the user to import the helper workflow:
+   ```
+   To set up the Slot Creator:
+
+   1. In n8n, go to your project folder
+   2. Import the file: n8n-sdlc/helpers/slot-creator-workflow.json
+   3. Open the imported "SDLC Slot Creator" workflow
+   4. Toggle it to Active
+   5. Click the Webhook node ("Receive Request")
+   6. Copy the Production webhook URL
+
+   Paste the webhook URL here when ready.
+   ```
+2. Wait for the user to provide the webhook URL
+3. Store in config as `slotCreator.webhookUrl`
+4. Confirm:
+   ```
+   Slot Creator configured! The reserve step will use this
+   webhook to auto-create workflow slots.
+
+   Note: You'll need an n8n API key when the reserve step runs.
+   The API key is asked for at that time and is never stored.
+   ```
+
+**Option 2 -- Skip:**
+1. Leave `slotCreator.webhookUrl` as `""` in config
+2. The reserve skill will fall back to manual slot creation
+
+### Question 6: .gitignore
 
 Check if `.gitignore` exists in the workspace root.
 
@@ -208,7 +250,7 @@ Want me to append these? (Your existing entries won't be changed.)
 
 Only append entries the user approves. Never remove or modify existing entries.
 
-### Optional: Project name and credentials
+### Question 7 (Optional): Project name and credentials
 
 After the core questions:
 1. **Project Name** (optional): A display name for logs (e.g., `Billing Bot`). Can be added later.
@@ -228,6 +270,7 @@ After the core questions:
   "naming": { "devPrefix": "DEV-" },
   "folderStrategy": { "mode": "flat", "dedicatedTools": "flat" },
   "git": { "enabled": true, "devBranch": "dev", "mainBranch": "main", "autoPush": true },
+  "slotCreator": { "webhookUrl": "" },
   "tags": { "dev": ["environment:dev"], "prod": ["environment:prod"] },
   "credentials": {},
   "createdAt": "{ISO timestamp}",
@@ -241,6 +284,7 @@ Field notes:
 - `workflowsDir`: User's chosen base path, or `""` for workspace root.
 - `folderStrategy`: From Question 3 answers.
 - `git`: From Question 4 answers. Omit or set `enabled: false` if no git.
+- `slotCreator`: From Question 5. Empty string if skipped.
 
 ### `n8n-sdlc/config/id-mappings.json`
 

--- a/.cursor/skills/n8n-sdlc-import-project/SKILL.md
+++ b/.cursor/skills/n8n-sdlc-import-project/SKILL.md
@@ -253,37 +253,64 @@ Examples:
   tools/Support Agent/Ticket Lookup.json  (if grouped strategy)
 ```
 
-## Step 9: Prompt for DEV Slot Creation
+## Step 9: Create DEV Slots
 
-Tell the user how many DEV slots are needed:
+After registering all workflows as PROD, check `n8n-sdlc/config/project.json` for `slotCreator.webhookUrl`.
+
+### If Slot Creator is configured:
+
+Offer to auto-create DEV slots immediately:
 
 ```
-NEXT STEPS: DEV Slot Creation
+NEXT STEP: DEV Slot Creation
+===========================================================
+
+You have {N} production workflows registered. I can auto-create
+{N} DEV slots using the Slot Creator.
+
+Shall I create and claim {N} DEV slots now? (yes/no)
+
+DEV workflows to create:
+  - DEV-Support Agent
+  - DEV-Billing Agent
+  - DEV-List Invoices
+  - DEV-Ticket Lookup
+  - DEV-Get Totals
+```
+
+If the user says **yes**: invoke the reserve skill logic directly in handoff mode. The reserve skill will read `id-mappings.json` for all `dev.status: "needs-slot"` entries and use the Slot Creator webhook to create and claim them.
+
+If the user says **no** or **later**: show the manual instructions below and let the user run "reserve workflows" when ready.
+
+### If Slot Creator is NOT configured:
+
+Show manual instructions:
+
+```
+NEXT STEP: DEV Slot Creation
 ===========================================================
 
 You have {N} production workflows registered. To enable the
 DEV/PROD workflow, you need {N} empty DEV slots.
 
-Please go to n8n and create {N} empty workflows in your
-project folder.
+Say "reserve workflows" and I'll walk you through creating
+and claiming them.
 
-Name suggestions (or use any names -- they'll be renamed):
-  1. DEV slot 1
-  2. DEV slot 2
-  ...
-
-When done, say "reserve workflows" and I'll claim the slots
-and rename them to your DEV workflow names:
+DEV workflows needed:
   - DEV-Support Agent
   - DEV-Billing Agent
   - DEV-List Invoices
   - DEV-Ticket Lookup
   - DEV-Get Totals
 
-After reserving, use the "seed dev" skill to populate each DEV
-workflow from its PROD version (with ID transformation).
+TIP: Set up the Slot Creator helper workflow to automate this
+step. See n8n-sdlc/helpers/README.md for instructions.
+```
 
-RECOMMENDED ORDER (bottom-up):
+### In both cases, include the recommended seeding order:
+
+```
+RECOMMENDED SEEDING ORDER (bottom-up):
   1. Get Totals, List Invoices, Ticket Lookup (leaf tools)
   2. Billing Agent (sub-agent)
   3. Support Agent (top-level agent)

--- a/.cursor/skills/n8n-sdlc-reserve-workflows/SKILL.md
+++ b/.cursor/skills/n8n-sdlc-reserve-workflows/SKILL.md
@@ -7,56 +7,141 @@ Reserve and claim workflow slots in n8n using the "Reserve and Claim" pattern.
 
 ## When to Use
 
-- After running the "Getting Started" skill
-- When you need new workflow slots for dev and/or prod
+- After the import-project skill discovers workflows (handoff mode)
+- After the getting-started wizard for greenfield projects
 - User says "reserve workflows", "claim slots", "set up workflow IDs"
 
 ## Why This Pattern Exists
 
-**The n8n MCP server creates new workflows in the "Personal" folder, not in project folders.**
+**The n8n MCP server and REST API create new workflows in the "Personal" folder, not in project folders.**
 
-To get workflows into the correct project folder, we must:
-1. Have the user manually create empty workflows in n8n
-2. Pull those workflows to get their IDs
-3. Claim the IDs for specific dev/prod workflow purposes
+To get workflows into the correct project folder, we either:
+- **Automated path**: Use the Slot Creator helper workflow (webhook) to bulk-create and transfer workflows to the project folder
+- **Manual path**: Have the user create empty workflows in the n8n UI, then pull and claim them
 
 ## Prerequisites
 
 - `n8n-sdlc/config/project.json` must exist (run Getting Started first)
 - `n8n-sdlc/config/id-mappings.json` must exist
-- User must have access to n8n UI
+- n8n MCP server must be available
 
-## Steps
+## Step 1: Determine Input Mode
 
-### Step 1: Determine Slots Needed
+Check how this skill was invoked:
 
-Ask the user what workflows they need to create. For each workflow, they need:
-- 1 DEV slot
-- 1 PROD slot (if they plan to promote)
+### Mode A: Handoff from Import
 
-**Example question:**
+If invoked after the import-project skill, the needed slots are already known. Read `n8n-sdlc/config/id-mappings.json` and find all workflows with `dev.status: "needs-slot"`:
+
 ```
-What workflows do you need to create? 
+Read id-mappings.json
+Filter workflows where dev.status === "needs-slot"
+These are the workflows that need DEV slots.
+```
 
-For each workflow, you'll need TWO slots (one dev, one prod).
+Skip to Step 2 with this pre-built list. Do NOT ask the user what workflows they need.
 
-Please list the workflow names (these will be the production names, e.g., 'Support Agent', 'List Invoices'):
+### Mode B: Standalone (User-Invoked)
+
+Ask the user what workflows they need:
+
+```
+What workflows do you need to create?
+
+For each workflow, do you need:
+  1. DEV slot only (you already have a PROD workflow)
+  2. Both DEV and PROD slots (new/greenfield workflow)
+
+Please list the workflow names (these are the production names):
 1. Support Agent
 2. List Invoices
 3. Get Invoice Totals
 ```
 
-### Step 2: Calculate Total Slots
+### Mode C: Greenfield
+
+If the project has no existing workflows (fresh setup), all workflows need BOTH DEV and PROD slots:
 
 ```
-Total slots needed = Number of workflows × 2 (dev + prod)
-
-Example: 3 workflows = 6 empty slots needed
+Total slots = Number of workflows × 2
 ```
 
-### Step 3: Instruct User to Create Empty Workflows
+## Step 2: Calculate Slots Needed
 
-Tell the user:
+Count the total empty workflow slots required:
+
+| Scenario | Slots per workflow |
+|----------|--------------------|
+| Post-import (DEV only) | 1 |
+| Greenfield (DEV + PROD) | 2 |
+| Mixed | Varies |
+
+Build a names list for the slots. For DEV slots, use `{devPrefix}{WorkflowName}`. For PROD slots, use `{WorkflowName}`.
+
+Read `naming.devPrefix` from `n8n-sdlc/config/project.json` (default: `"DEV-"`).
+
+```
+Example (post-import, 5 workflows):
+  Slots needed: 5
+  Names: ["DEV-Support Agent", "DEV-Billing Agent", "DEV-List Invoices", "DEV-Ticket Lookup", "DEV-Get Totals"]
+
+Example (greenfield, 3 workflows):
+  Slots needed: 6
+  Names: ["DEV-Support Agent", "Support Agent", "DEV-List Invoices", "List Invoices", "DEV-Get Totals", "Get Totals"]
+```
+
+## Step 3: Create Empty Workflow Slots
+
+Read `n8n-sdlc/config/project.json` and check if `slotCreator.webhookUrl` is set.
+
+### Step 3A: Automated Creation (Slot Creator configured)
+
+If `slotCreator.webhookUrl` is set and non-empty:
+
+1. Extract the base URL from the webhook URL (everything before `/webhook/`).
+2. Build the request payload:
+
+```json
+{
+  "projectId": "{n8nProjectId from project.json}",
+  "count": {total slots needed},
+  "names": ["{list of slot names}"],
+  "baseUrl": "{extracted base URL}",
+  "apiKey": "{user must provide — ask once, do not store}"
+}
+```
+
+3. **Ask the user for their n8n API key** (needed for the slot creator to call the n8n REST API). Do not store this value anywhere.
+
+4. Call the webhook:
+
+```bash
+curl -s -X POST "{webhookUrl}" \
+  -H "Content-Type: application/json" \
+  -d '{payload}'
+```
+
+5. Parse the response:
+
+```json
+{
+  "success": true,
+  "created": [{"id": "abc123", "name": "DEV-Support Agent"}, ...],
+  "count": 5,
+  "requested": 5,
+  "errors": []
+}
+```
+
+6. **Verify**: Check that `count` matches `requested`. If `errors` is non-empty, report them.
+
+7. **On total failure** (webhook unreachable, HTTP error, success=false with 0 created): Fall back to Step 3B (manual).
+
+8. **On partial failure** (some created, some failed): Report what was created, ask user if they want to manually create the remaining slots (Step 3B for the remainder) or retry.
+
+### Step 3B: Manual Creation (No Slot Creator or fallback)
+
+If `slotCreator.webhookUrl` is not set or the automated path failed:
 
 ```
 Please go to n8n and create {N} empty workflows:
@@ -64,186 +149,211 @@ Please go to n8n and create {N} empty workflows:
 1. Go to your n8n instance
 2. Navigate to your project folder
 3. Create {N} new empty workflows
-   - The names don't matter yet (you can call them "Slot 1", "Slot 2", etc.)
-   - Just make sure they're in the correct folder!
+   - The names don't matter (you can call them "Slot 1", "Slot 2", etc.)
+   - Make sure they're in the correct project folder!
 
-When you're done, say "done" or "ready" and I'll pull them to get their IDs.
+When you're done, say "done" and I'll pull them to get their IDs.
+
+TIP: To skip this manual step in the future, set up the Slot Creator
+helper workflow. See n8n-sdlc/helpers/README.md for instructions.
 ```
 
-### Step 4: Wait for User Confirmation
+Wait for user confirmation, then:
 
-Wait for user to confirm they've created the workflows.
-
-### Step 5: Pull Workflows from n8n
-
-Use the n8n MCP server to list/pull workflows:
-
-```
-Use n8n MCP: n8n_list_workflows with projectId from n8n-sdlc/config/project.json (n8nProjectId).
-Filter by: 
-  - Empty or minimal content
-  - Recently created (createdAt)
-```
-
-Always pass `projectId` from project.json so only workflows in the locked project are listed.
-
-### Step 6: Identify New Empty Workflows
-
-Present the list of potential empty workflows to the user:
+1. Use n8n MCP: `n8n_list_workflows` with `projectId` from project.json
+2. Filter for empty/minimal workflows (`nodeCount` of 0 or 1)
+3. Filter for recently created workflows
+4. Present the list to the user for confirmation:
 
 ```
-I found these workflows that might be your new empty slots:
+I found these empty workflows in your project:
 
 1. ID: abc123 | Name: "Slot 1" | Created: 2026-02-05
 2. ID: def456 | Name: "Slot 2" | Created: 2026-02-05
-3. ID: ghi789 | Name: "Slot 3" | Created: 2026-02-05
 ...
 
-Please confirm these are the correct workflows you just created.
+Are these the workflows you just created? (yes/no)
 ```
 
-After resolving each workflow ID, call `n8n_get_workflow` (mode: "full"); if `data.shared[0].projectId` does not match `n8n-sdlc/config/project.json` n8nProjectId, exclude that workflow from the list and do not allow claim (workflow is not in the locked project). Use `nodeCount` from the list response to identify empty slots (nodeCount of 0 or 1 = empty/minimal).
+For each confirmed workflow, call `n8n_get_workflow` (mode: "full") and verify `data.shared[0].projectId` matches `n8nProjectId`. Exclude any that don't match.
 
-### Step 7: Claim Slots for Specific Workflows
+## Step 4: Auto-Assign Slots
 
-For each workflow the user wants to create, ask them to assign slots:
+**Empty slots are fungible** — any empty slot can become any workflow. Do not ask the user to manually assign each slot.
+
+### Automated Path (Step 3A)
+
+Slots were pre-named during creation. Match by name:
 
 ```
-Now let's assign these slots to your workflows.
-
-For each workflow, I need a DEV slot and a PROD slot:
-
-Workflow: Support Agent
-  - DEV slot: [User selects from list, e.g., "1"]
-  - PROD slot: [User selects from list, e.g., "2"]
-
-Workflow: List Invoices
-  - DEV slot: [User selects, e.g., "3"]
-  - PROD slot: [User selects, e.g., "4"]
+For each needed workflow:
+  Find the created slot whose name matches "{devPrefix}{WorkflowName}" (for DEV)
+  or "{WorkflowName}" (for PROD)
+  Assign that slot's ID to the workflow
 ```
 
-### Step 8: Update id-mappings.json
+### Manual Path (Step 3B)
 
-Add entries for each claimed workflow. Include `localPath`:
-- Default to `"agents/"` for AI workflows (type: agent)
-- Default to `"tools/"` for others (type: tool)
-- If the project has `folderStrategy.mode: "categorized"`, use the appropriate path for that strategy (e.g., nested paths)
+Assign slots in order:
 
-Read `n8n-sdlc/config/project.json` to get `naming.devPrefix` and `folderStrategy` (if present).
+```
+Confirmed empty slots: [abc123, def456, ghi789, jkl012, mno345]
+Needed workflows (DEV): [Support Agent, Billing Agent, List Invoices, Ticket Lookup, Get Totals]
 
+Assignment:
+  DEV-Support Agent  → abc123
+  DEV-Billing Agent  → def456
+  DEV-List Invoices  → ghi789
+  DEV-Ticket Lookup  → jkl012
+  DEV-Get Totals     → mno345
+```
+
+Show the mapping and ask for a **single confirmation**:
+
+```
+Here's the slot assignment:
+
+┌──────────────────────┬──────────────────┐
+│ Workflow             │ Slot ID          │
+├──────────────────────┼──────────────────┤
+│ DEV-Support Agent    │ abc123           │
+│ DEV-Billing Agent    │ def456           │
+│ DEV-List Invoices    │ ghi789           │
+│ DEV-Ticket Lookup    │ jkl012           │
+│ DEV-Get Totals       │ mno345           │
+└──────────────────────┴──────────────────┘
+
+Does this look correct? (yes/no)
+```
+
+If the user says no, let them swap specific entries. Do not re-ask for each one individually.
+
+## Step 5: Update id-mappings.json
+
+For each claimed workflow, update the entry in `id-mappings.json`:
+
+**Post-import (DEV slots only)** — update existing entries:
 ```json
 {
-  "workflows": {
-    "Support Agent": {
-      "type": "agent",
-      "localPath": "agents/",
-      "dev": {
-        "id": "abc123",
-        "status": "reserved"
-      },
-      "prod": {
-        "id": "def456",
-        "status": "reserved"
-      }
+  "Support Agent": {
+    "type": "agent",
+    "localPath": "agents/",
+    "dev": {
+      "id": "abc123",
+      "status": "reserved"
     },
-    "List Invoices": {
-      "type": "tool",
-      "localPath": "tools/",
-      "dev": {
-        "id": "ghi789",
-        "status": "reserved"
-      },
-      "prod": {
-        "id": "jkl012",
-        "status": "reserved"
-      }
+    "prod": {
+      "id": "existingProdId",
+      "status": "active"
     }
   }
 }
 ```
 
-### Step 9: Rename Workflows in n8n (Optional but Recommended)
+**Greenfield (DEV + PROD)** — create new entries:
+```json
+{
+  "Support Agent": {
+    "type": "agent",
+    "localPath": "agents/",
+    "dev": {
+      "id": "abc123",
+      "status": "reserved"
+    },
+    "prod": {
+      "id": "def456",
+      "status": "reserved"
+    }
+  }
+}
+```
+
+For `localPath`:
+- Default `"agents/"` for AI workflows (type: agent)
+- Default `"tools/"` for others (type: tool)
+- If the project has `folderStrategy.mode: "categorized"`, use the appropriate nested path
+
+Read `folderStrategy` from `n8n-sdlc/config/project.json`.
+
+## Step 6: Rename Workflows in n8n
 
 Use MCP to update workflow names:
 
-- **DEV slots only**: Rename to `"{devPrefix}{WorkflowName}"` (e.g., `"DEV-Support Agent"`). Get `devPrefix` from `n8n-sdlc/config/project.json` → `naming.devPrefix` (default `"DEV-"`).
-- **PROD slots**: Keep whatever name the user gave them in n8n. If the user named a slot "Slot 2" but it's claimed as "Support Agent", optionally rename it to "Support Agent" so it matches the logical name.
+- **DEV slots**: Rename to `"{devPrefix}{WorkflowName}"` (e.g., `"DEV-Support Agent"`)
+- **PROD slots** (greenfield only): Rename to `"{WorkflowName}"` if the current name doesn't match
 
-**Example MCP operation:**
+**Skip renaming for automated path (3A)** — slots were already created with correct names.
+
+For manual path (3B), rename using:
 ```
-Update workflow abc123 (DEV slot):
-  - name: "DEV-Support Agent"
-  
-Update workflow def456 (PROD slot):
-  - name: "Support Agent"   (only if it was named something else like "Slot 2")
+n8n_update_partial_workflow with updateName operation:
+  - workflow abc123 → name: "DEV-Support Agent"
+  - workflow def456 → name: "DEV-Billing Agent"
+  ...
 ```
 
-### Step 10: Confirm Completion
-
-Tell the user:
+## Step 7: Confirm Completion
 
 ```
-Workflow slots have been reserved and claimed!
+Workflow slots reserved and claimed!
 
 Summary:
-┌─────────────────┬──────────────────────────────────────┬──────────────────────────────────────┐
-│ Workflow        │ DEV ID                               │ PROD ID                              │
-├─────────────────┼──────────────────────────────────────┼──────────────────────────────────────┤
-│ Support Agent   │ abc123                               │ def456                               │
-│ List Invoices   │ ghi789                               │ jkl012                               │
-└─────────────────┴──────────────────────────────────────┴──────────────────────────────────────┘
-
-The DEV workflows have been renamed in n8n (prefixed with {devPrefix}). PROD workflows keep their names.
+┌─────────────────┬──────────────────┬──────────────────┐
+│ Workflow        │ DEV ID           │ PROD ID          │
+├─────────────────┼──────────────────┼──────────────────┤
+│ Support Agent   │ abc123           │ existingProdId   │
+│ Billing Agent   │ def456           │ existingProdId2  │
+│ List Invoices   │ ghi789           │ existingProdId3  │
+└─────────────────┴──────────────────┴──────────────────┘
 
 Next steps:
-1. Build your workflows in the DEV slots
-2. When ready, use the "Promote" skill to push to prod
+1. Use the "seed dev" skill to populate DEV from PROD (recommended order: bottom-up)
+2. Or build workflows directly in the DEV slots
+3. When ready, use the "promote" skill to push to prod
 ```
 
-## Handling Existing Workflows
-
-If the user has existing workflows they want to import:
-
-1. Ask for the workflow names/IDs
-2. Pull each workflow
-3. Verify they're in the correct folder
-4. Add them to id-mappings.json with appropriate status and localPath
-5. Optionally rename DEV copies to follow conventions (prepend devPrefix)
+If post-import, include the recommended seeding order (bottom-up from leaf tools to top-level agents).
 
 ## Error Handling
 
 | Error | Resolution |
 |-------|------------|
-| Can't find new workflows | Ask user to verify they created them in correct folder |
-| Duplicate IDs | Prevent - each ID can only be claimed once |
 | project.json missing | Run Getting Started skill first |
-| MCP not available | Provide manual instructions for user |
+| id-mappings.json missing | Run Getting Started skill first |
+| MCP not available | Provide manual instructions |
+| Slot Creator webhook unreachable | Fall back to manual path (Step 3B) |
+| Slot Creator partial failure | Report errors, offer manual creation for remainder |
+| Can't find empty workflows (manual) | Ask user to verify they created them in correct folder |
+| Duplicate IDs | Prevent — each ID can only be claimed once |
+| Workflow not in locked project | Exclude from list, warn user |
+| Slot count mismatch | Report discrepancy, ask user how to proceed |
 
 ## Validation Checks
 
 Before claiming:
-1. Verify each ID is unique (not already in mappings)
-2. Verify workflow exists in n8n
-3. Verify naming doesn't conflict with existing entries
+1. Verify each ID is unique (not already in id-mappings)
+2. Verify workflow exists in n8n (via MCP)
+3. Verify workflow is in the locked project (shared[0].projectId check)
+4. Verify naming doesn't conflict with existing entries
 
 ## MCP Commands Used
 
-This skill uses the following n8n MCP operations:
-- `n8n_list_workflows` - List workflows (always pass `projectId`). Returns id, name, active, createdAt, updatedAt, tags, nodeCount.
-- `n8n_get_workflow` - Get specific workflow by ID (mode: "full" to verify `shared[0].projectId`)
-- `n8n_update_partial_workflow` - Rename workflows after claiming (use `updateName` operation)
+- `n8n_list_workflows` — List workflows (always pass `projectId`). Returns id, name, active, createdAt, updatedAt, tags, nodeCount.
+- `n8n_get_workflow` — Get specific workflow by ID (mode: "full" to verify `shared[0].projectId`)
+- `n8n_update_partial_workflow` — Rename workflows after claiming (use `updateName` operation)
 
-### Git Sync
+## Git Sync
 
 After claiming slots, run the **n8n-sdlc-git-sync** skill with:
 - Files: `n8n-sdlc/config/id-mappings.json`
 - Message: `[reserve] Claimed {N} DEV slots`
-- Example: `[reserve] Claimed 3 DEV slots`
+- Example: `[reserve] Claimed 5 DEV slots`
 
 ## Related Skills
 
-- **n8n-sdlc-getting-started** - The setup wizard; run before this skill
-- **n8n-sdlc-import-project** - Discovers and registers existing workflows
-- **n8n-sdlc-push-workflow** - After reserving, use this to push content
-- **n8n-sdlc-pull-workflow** - Can be used to import existing workflows
-- **n8n-sdlc-git-sync** - Called automatically after reserving to commit and push to git
+- **n8n-sdlc-getting-started** — The setup wizard; run before this skill
+- **n8n-sdlc-import-project** — Discovers and registers existing workflows; hands off to this skill
+- **n8n-sdlc-seed-dev** — After reserving, populate DEV from PROD
+- **n8n-sdlc-push-workflow** — Push local workflow content to n8n
+- **n8n-sdlc-pull-workflow** — Pull workflows from n8n to local
+- **n8n-sdlc-git-sync** — Called automatically after reserving to commit and push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# n8n SDLC Framework
+
+This project provides dev/prod workflow separation for n8n, which lacks native SDLC capabilities. The AI agent manages workflow versioning, promotion, and synchronization using n8n MCP, config files, and git.
+
+## How This Works
+
+Cursor users get auto-loaded rules and skills from `.cursor/rules/` and `.cursor/skills/`. Claude Code users (you) get this file as the entry point. **Read the referenced SKILL.md file before executing any skill operation.**
+
+## Core Rules
+
+These rules are always active. Full details in `.cursor/rules/n8n-sdlc.md`.
+
+### MCP Folder Constraint
+The n8n MCP server (and REST API) creates workflows in "Personal", not project folders. NEVER use `n8n_create_workflow`. Use the Reserve and Claim pattern instead:
+1. Create empty slots in the project folder (automated via Slot Creator or manual)
+2. Claim slots by recording IDs in `n8n-sdlc/config/id-mappings.json`
+3. Update workflows via MCP with actual content
+
+### Project Scoping
+All MCP operations are locked to the project ID in `n8n-sdlc/config/project.json` (`n8nProjectId`). Always pass `projectId` when listing workflows. Verify `shared[0].projectId` before any update.
+
+### Naming Conventions
+- **PROD**: Original name (e.g., `Support Agent`)
+- **DEV**: Prefix from config (e.g., `DEV-Support Agent`)
+- Dev prefix configured in `project.json` → `naming.devPrefix` (default: `DEV-`)
+
+### Safety
+- NEVER push to PROD without explicit user confirmation
+- NEVER promote if any in-project workflowId reference lacks a prod mapping
+- External dependency references are left untouched (same ID in DEV and PROD)
+- Backup PROD state locally before overwriting
+- Complete operations fully or not at all (no partial states)
+
+### Forbidden Actions
+1. Push to PROD without explicit "confirm"
+2. Create workflows via MCP (`n8n_create_workflow`)
+3. Promote with unmapped in-project references
+4. Delete or overwrite id-mappings.json without backup
+5. Modify workflows outside the locked project
+
+## Available Skills
+
+Each skill has a SKILL.md with full step-by-step instructions. **Read the SKILL.md before executing.**
+
+| Skill | File | Triggers |
+|-------|------|----------|
+| **Get Started** | `.cursor/skills/n8n-sdlc-getting-started/SKILL.md` | "get started", "set up SDLC", "onboard" |
+| **Import Project** | `.cursor/skills/n8n-sdlc-import-project/SKILL.md` | "import project", "discover workflows" |
+| **Reserve Workflows** | `.cursor/skills/n8n-sdlc-reserve-workflows/SKILL.md` | "reserve workflows", "claim slots" |
+| **Seed DEV** | `.cursor/skills/n8n-sdlc-seed-dev/SKILL.md` | "seed dev", "populate dev from prod" |
+| **Push Workflow** | `.cursor/skills/n8n-sdlc-push-workflow/SKILL.md` | "push workflow", "update in n8n" |
+| **Pull Workflow** | `.cursor/skills/n8n-sdlc-pull-workflow/SKILL.md` | "pull workflow", "download from n8n" |
+| **Promote** | `.cursor/skills/n8n-sdlc-promote-workflow/SKILL.md` | "promote", "push to prod" |
+| **Validate** | `.cursor/skills/n8n-sdlc-validate-workflow/SKILL.md` | "validate workflow", "check workflow" |
+| **Project Status** | `.cursor/skills/n8n-sdlc-project-status/SKILL.md` | "project status", "show status" |
+| **Git Sync** | `.cursor/skills/n8n-sdlc-git-sync/SKILL.md` | Called automatically by other skills |
+| **Diff Workflows** | `.cursor/skills/n8n-sdlc-diff-workflows/SKILL.md` | "diff workflows", "compare dev prod" |
+| **Rollback** | `.cursor/skills/n8n-sdlc-rollback/SKILL.md` | "rollback", "revert workflow" |
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `n8n-sdlc/config/project.json` | Project config (IDs, naming, git, slot creator) |
+| `n8n-sdlc/config/id-mappings.json` | Workflow ID mappings (dev/prod pairs) |
+| `.cursor/rules/n8n-sdlc-workflow-structure.md` | JSON transformation reference for promote/seed |
+| `n8n-sdlc/helpers/slot-creator-workflow.json` | Helper workflow for automated slot creation |
+
+## Typical Workflows
+
+**New project with existing workflows:**
+Get Started → Import Project → Reserve Workflows → Seed DEV
+
+**Greenfield project:**
+Get Started → Reserve Workflows → Build in DEV → Promote to PROD
+
+**Day-to-day development:**
+Pull → Edit locally → Push to DEV → Test → Promote to PROD

--- a/install.sh
+++ b/install.sh
@@ -243,6 +243,13 @@ echo ""
 install_skills "$TARGET"
 install_rules "$TARGET"
 install_sdlc_folder "$TARGET"
+
+# Copy CLAUDE.md for Claude Code compatibility
+if [[ -f "$SCRIPT_DIR/CLAUDE.md" ]]; then
+    log_info "Claude Code config (CLAUDE.md)"
+    copy_file "$SCRIPT_DIR/CLAUDE.md" "$TARGET/CLAUDE.md" "CLAUDE.md"
+fi
+
 write_sdlc_version "$TARGET"
 
 echo ""
@@ -262,7 +269,7 @@ else
     if ! $UPDATE; then
         echo ""
         echo "Next steps:"
-        echo "  1. Open the project in Cursor"
+        echo "  1. Open the project in Cursor or Claude Code"
         echo "  2. Say \"get started\" to the AI to initialize your n8n project"
     fi
 fi

--- a/n8n-sdlc/config/project.json.template
+++ b/n8n-sdlc/config/project.json.template
@@ -23,6 +23,9 @@
     "mainBranch": "main",
     "autoPush": true
   },
+  "slotCreator": {
+    "webhookUrl": ""
+  },
   "credentials": {
     "$comment": "Map credentials that differ between dev and prod. Format: alias -> {dev: id, prod: id}",
     "$example_slack": {

--- a/n8n-sdlc/config/project.schema.json
+++ b/n8n-sdlc/config/project.schema.json
@@ -127,6 +127,18 @@
       },
       "additionalProperties": false
     },
+    "slotCreator": {
+      "type": "object",
+      "description": "Optional config for automated slot creation via helper workflow. When configured, the reserve skill can auto-create empty workflow slots instead of requiring manual creation in the n8n UI.",
+      "properties": {
+        "webhookUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Webhook URL of the slot-creator helper workflow deployed in your n8n instance."
+        }
+      },
+      "additionalProperties": false
+    },
     "createdAt": {
       "type": "string",
       "format": "date-time",

--- a/n8n-sdlc/docs/Team-Onboarding.md
+++ b/n8n-sdlc/docs/Team-Onboarding.md
@@ -10,11 +10,18 @@ This repository is the **SDLC framework** -- a portable toolkit of rules, skills
 
 Before starting, you need:
 
-1. **Cursor IDE** installed
+1. **Cursor IDE or Claude Code** (either works — see AI Tool Support below)
 2. **Access to your n8n instance** (e.g., https://n8n.tech.pax8.com)
 3. **n8n user account** with access to the project(s) you'll be developing
 4. **Git access** to the SDLC repository
 5. **n8n API key** for MCP authentication
+
+### AI Tool Support
+
+Both **Cursor** and **Claude Code** are supported:
+
+- **Cursor**: Rules and skills are auto-loaded from `.cursor/rules/` and `.cursor/skills/`. Skills appear as Cursor commands.
+- **Claude Code**: Reads `CLAUDE.md` at the project root for rules and skill index. Say a trigger phrase (e.g., "get started", "reserve workflows") and the AI will read the relevant SKILL.md before executing.
 
 ## Step 1: Set Up Your Project Workspace
 
@@ -124,6 +131,38 @@ Run an n8n health check
 
 You should see a successful connection to your n8n instance with version info and available tools.
 
+## Step 3b: Set Up the Slot Creator (Optional)
+
+The Slot Creator is a helper n8n workflow that automates the creation of empty workflow slots. Without it, you must manually create empty workflows in the n8n UI before the reserve step can claim them. With it, the AI agent creates and transfers them automatically.
+
+### Setup
+
+1. Import the workflow file `n8n-sdlc/helpers/slot-creator-workflow.json` into your n8n project
+2. Open the imported "SDLC Slot Creator" workflow
+3. Toggle it to **Active**
+4. Click the Webhook node ("Receive Request") and copy the **Production** webhook URL
+5. Add the URL to `n8n-sdlc/config/project.json`:
+   ```json
+   "slotCreator": {
+     "webhookUrl": "https://your-n8n.example.com/webhook/sdlc/create-slots"
+   }
+   ```
+
+### Requirements
+
+- **n8n 1.30+** (requires `fetch` in Code nodes)
+- **n8n REST API enabled** with a valid API key
+- **Project transfer support** (Enterprise or Community Edition with projects)
+
+### Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `Create failed (HTTP 401)` | Invalid API key | Verify API key is correct and active |
+| `Transfer failed (HTTP 404)` | Transfer endpoint unavailable | Check n8n version supports project transfers |
+| `Transfer failed (HTTP 400)` | Invalid project ID | Verify `n8nProjectId` matches your project |
+| `fetch is not defined` | n8n version too old | Upgrade to n8n 1.30+ |
+
 ## Step 4: Understand the Project Structure
 
 Workflow JSON files live in folders specified by `localPath` in `n8n-sdlc/config/id-mappings.json` (per workflow). Two layouts are supported:
@@ -184,9 +223,10 @@ This will list all workflows and their current state. Verify you can see the wor
 
 ### Reserve and Claim Pattern
 
-The MCP **cannot** create workflows in the correct n8n folder. All new workflows must be:
-1. Created manually by a human in the n8n UI (in the correct project folder)
-2. "Claimed" via the SDLC system to register their IDs
+The MCP **cannot** create workflows in the correct n8n project folder. Two paths are available:
+
+- **Automated (Slot Creator)**: If the Slot Creator helper workflow is configured (see Step 3b), the AI agent creates empty slots via webhook and claims them automatically. No manual steps required.
+- **Manual**: Create empty workflows by hand in the n8n UI (in the correct project folder), then say "reserve workflows" so the SDLC system can claim and register their IDs.
 
 ### Naming Convention
 

--- a/n8n-sdlc/helpers/README.md
+++ b/n8n-sdlc/helpers/README.md
@@ -1,0 +1,93 @@
+# n8n SDLC Helper Workflows
+
+Helper workflows that run inside your n8n instance to support SDLC operations.
+
+## Slot Creator
+
+**File:** `slot-creator-workflow.json`
+
+Creates empty workflow slots in bulk and transfers them to your project folder. This eliminates the need to manually create empty workflows in the n8n UI before the reserve step.
+
+### Why This Exists
+
+The n8n API creates new workflows in the "Personal" folder, not in project folders. This helper works around that limitation by:
+
+1. Creating empty workflows via `POST /api/v1/workflows`
+2. Transferring each to the target project via `PUT /api/v1/workflows/:id/transfer`
+
+### Setup
+
+1. **Get an n8n API key**
+   - Go to your n8n instance Settings > API
+   - Create a new API key (or use an existing one)
+   - Copy the key
+
+2. **Import the workflow**
+   - In n8n, go to your project folder
+   - Click "Add workflow" > "Import from file"
+   - Select `slot-creator-workflow.json`
+
+3. **Activate the workflow**
+   - Open the imported "SDLC Slot Creator" workflow
+   - Toggle it to Active
+
+4. **Copy the webhook URL**
+   - Click the Webhook node ("Receive Request")
+   - Copy the **Production** webhook URL
+   - It will look like: `https://your-n8n.example.com/webhook/sdlc/create-slots`
+
+5. **Save the URL in your project config**
+   - Open `n8n-sdlc/config/project.json`
+   - Set `slotCreator.webhookUrl` to the copied URL
+
+### How It Works
+
+The AI agent calls the webhook during the reserve step with:
+
+```json
+{
+  "projectId": "your-n8n-project-id",
+  "count": 5,
+  "baseUrl": "https://your-n8n.example.com",
+  "apiKey": "your-n8n-api-key",
+  "names": ["DEV-Support Agent", "DEV-Billing Agent", "DEV-List Invoices", "DEV-Ticket Lookup", "DEV-Get Totals"]
+}
+```
+
+Response:
+
+```json
+{
+  "success": true,
+  "created": [
+    {"id": "abc123", "name": "DEV-Support Agent"},
+    {"id": "def456", "name": "DEV-Billing Agent"}
+  ],
+  "count": 5,
+  "requested": 5,
+  "errors": []
+}
+```
+
+### Requirements
+
+- **n8n version**: 1.30+ (requires `fetch` support in Code nodes)
+- **n8n API**: REST API must be enabled with a valid API key
+- **Enterprise feature**: The workflow transfer endpoint (`PUT /workflows/:id/transfer`) requires n8n Enterprise or Community Edition with project support
+
+### Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `Create failed (HTTP 401)` | Invalid API key | Check the API key is correct and active |
+| `Transfer failed (HTTP 404)` | Transfer endpoint unavailable | Verify your n8n version supports project transfers |
+| `Transfer failed (HTTP 400)` | Invalid project ID | Check `projectId` matches your n8n project |
+| `fetch is not defined` | n8n version too old | Upgrade to n8n 1.30+ or rewrite Code node to use HTTP Request nodes |
+| Workflows created but in "Personal" | Transfer step failed | Check errors array in response; verify project ID |
+
+### Security Notes
+
+- The webhook URL acts as a shared secret (unguessable UUID path)
+- The API key is passed per-request, not stored in the workflow
+- The webhook should only be called from your local network or AI agent
+- Consider using n8n's webhook authentication options for additional security

--- a/n8n-sdlc/helpers/slot-creator-workflow.json
+++ b/n8n-sdlc/helpers/slot-creator-workflow.json
@@ -1,0 +1,73 @@
+{
+  "name": "SDLC Slot Creator",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "sdlc/create-slots",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [220, 340],
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "name": "Receive Request",
+      "webhookId": "d4e5f6a7-b8c9-0123-defa-234567890123"
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "// SDLC Slot Creator\n// Bulk-creates empty workflows and transfers them to a project folder.\n//\n// Required body fields:\n//   projectId  — n8n project ID (destination folder)\n//   count      — number of slots to create (1\u201350)\n//   baseUrl    — n8n instance URL (e.g. \"https://n8n.example.com\")\n//   apiKey     — n8n REST API key\n//\n// Optional:\n//   names      — array of workflow names (defaults to \"Slot 1\", \"Slot 2\", ...)\n\nconst input = $input.first().json;\n\nconst projectId = input.projectId;\nconst count = parseInt(input.count, 10);\nconst names = input.names || [];\nconst baseUrl = (input.baseUrl || '').replace(/\\/$/, '');\nconst apiKey = input.apiKey;\n\n// --- Validation ---\nconst missing = [];\nif (!projectId) missing.push('projectId');\nif (!baseUrl) missing.push('baseUrl');\nif (!apiKey) missing.push('apiKey');\n\nif (missing.length > 0) {\n  return [{ json: { success: false, error: `Missing required fields: ${missing.join(', ')}` } }];\n}\nif (isNaN(count) || count < 1 || count > 50) {\n  return [{ json: { success: false, error: 'count must be a number between 1 and 50' } }];\n}\n\n// --- Create and transfer each slot ---\nconst headers = {\n  'X-N8N-API-KEY': apiKey,\n  'Content-Type': 'application/json',\n};\n\nconst created = [];\nconst errors = [];\n\nfor (let i = 0; i < count; i++) {\n  const name = names[i] || `Slot ${i + 1}`;\n\n  try {\n    // 1. Create empty workflow (lands in Personal folder)\n    const createResp = await fetch(`${baseUrl}/api/v1/workflows`, {\n      method: 'POST',\n      headers,\n      body: JSON.stringify({\n        name,\n        nodes: [],\n        connections: {},\n        settings: { executionOrder: 'v1' },\n      }),\n    });\n\n    if (!createResp.ok) {\n      const errText = await createResp.text();\n      throw new Error(`Create failed (HTTP ${createResp.status}): ${errText}`);\n    }\n\n    const workflow = await createResp.json();\n\n    // 2. Transfer to target project folder\n    const transferResp = await fetch(\n      `${baseUrl}/api/v1/workflows/${workflow.id}/transfer`,\n      {\n        method: 'PUT',\n        headers,\n        body: JSON.stringify({ destinationProjectId: projectId }),\n      }\n    );\n\n    if (!transferResp.ok) {\n      const errText = await transferResp.text();\n      throw new Error(`Transfer failed (HTTP ${transferResp.status}): ${errText}`);\n    }\n\n    created.push({ id: workflow.id, name });\n  } catch (err) {\n    errors.push({ index: i, name, error: err.message });\n  }\n}\n\nreturn [{\n  json: {\n    success: errors.length === 0,\n    created,\n    count: created.length,\n    requested: count,\n    errors,\n  },\n}];\n"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [480, 340],
+      "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+      "name": "Create Slots"
+    },
+    {
+      "parameters": {
+        "respondWith": "allIncomingItems",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [740, 340],
+      "id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+      "name": "Send Response"
+    }
+  ],
+  "connections": {
+    "Receive Request": {
+      "main": [
+        [
+          {
+            "node": "Create Slots",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Slots": {
+      "main": [
+        [
+          {
+            "node": "Send Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "versionId": "1",
+  "meta": {
+    "templateCredsSetupCompleted": true
+  },
+  "tags": []
+}


### PR DESCRIPTION
## Summary
- Adds a Slot Creator helper n8n workflow that automates empty workflow slot creation via webhook, eliminating the #1 adoption blocker (manual slot creation in the n8n UI)
- Rewrites the reserve skill with automated (webhook) and manual paths, plus auto-assign (slots are fungible — no interactive per-slot mapping needed)
- Adds Claude Code support via `CLAUDE.md` so the framework works in both Cursor and Claude Code

## Changes
- **New**: `n8n-sdlc/helpers/slot-creator-workflow.json` — webhook-triggered workflow that creates empty slots and transfers them to the correct project folder via `PUT /workflows/:id/transfer`
- **New**: `n8n-sdlc/helpers/README.md` — setup and troubleshooting guide
- **New**: `CLAUDE.md` — project instructions for Claude Code users (rules summary + skill index)
- **Modified**: Reserve skill — rewritten with automated path (3A) and manual fallback (3B)
- **Modified**: Import skill — offers immediate DEV slot creation after discovery when Slot Creator is configured
- **Modified**: Getting-started wizard — new optional Q5 for Slot Creator setup
- **Modified**: Schema + template — added `slotCreator.webhookUrl` config property
- **Modified**: Rules, onboarding docs, install script — updated for both paths + AI tool support

## Test plan
- [ ] Import `slot-creator-workflow.json` into n8n, verify it loads without errors
- [ ] Call webhook with `count: 1` — verify workflow appears in target project
- [ ] Call with `count: 5` and names array — verify 5 correctly-named workflows in project
- [ ] Call with invalid projectId — verify graceful error response
- [ ] Run getting-started wizard — verify Slot Creator question appears and URL is saved
- [ ] Run import → reserve with webhook configured — verify slots auto-created and claimed
- [ ] Run reserve without webhook — verify manual flow still works
- [ ] Open project in Claude Code — verify CLAUDE.md loads and skill triggers work

🤖 Generated with [Claude Code](https://claude.com/claude-code)