### PR TITLE
docs: clarify credential IDs are reference IDs, not secrets

### DIFF
--- a/n8n-sdlc/config/project.json.template
+++ b/n8n-sdlc/config/project.json.template
@@ -27,7 +27,7 @@
     "webhookUrl": ""
   },
   "credentials": {
-    "$comment": "Map credentials that differ between dev and prod. Format: alias -> {dev: id, prod: id}",
+    "$comment": "Map credentials that differ between dev and prod. Format: alias -> {dev: id, prod: id}. These are opaque n8n reference IDs, not secrets. Actual secrets live in n8n's encrypted credential vault.",
     "$example_slack": {
       "dev": "slack-sandbox-credential-id",
       "prod": "slack-production-credential-id"

--- a/n8n-sdlc/config/project.schema.json
+++ b/n8n-sdlc/config/project.schema.json
@@ -83,7 +83,7 @@
     },
     "credentials": {
       "type": "object",
-      "description": "Map credential aliases to their environment-specific n8n IDs. Only for credentials that differ between dev and prod. During promotion, iterate aliases and replace any node credential whose ID matches the 'dev' value with the 'prod' value.",
+      "description": "Map credential aliases to their environment-specific n8n IDs. Only for credentials that differ between dev and prod. During promotion, iterate aliases and replace any node credential whose ID matches the 'dev' value with the 'prod' value. Security note: these are opaque n8n-internal reference IDs, not secrets. Actual credential secrets (API keys, tokens, passwords) are stored in n8n's encrypted credential vault and are never exposed here. project.json is gitignored by default.",
       "additionalProperties": {
         "type": "object",
         "required": ["dev", "prod"],

--- a/n8n-sdlc/docs/Team-Onboarding.md
+++ b/n8n-sdlc/docs/Team-Onboarding.md
@@ -384,7 +384,23 @@ The SDLC automatically commits and pushes to your **project repo** (not the SDLC
 
 ## Security Notes
 
-- **API keys** are personal and should never be shared or committed
-- **Credential IDs** in `project.json` and `id-mappings.json` are n8n internal IDs, not secrets
-- **Workflow JSON** may contain credential references (IDs only, not actual secrets)
-- If you need to store actual secrets, use `n8n-sdlc/config/secrets.json` (gitignored)
+### API Keys
+
+Your n8n API key is personal and should never be shared or committed to git. Store it only in your local MCP configuration (Cursor settings or `.claude/settings.local.json`).
+
+### Credential IDs Are Not Secrets
+
+The `credentials` section in `project.json` contains **opaque n8n-internal reference IDs** (e.g., `UyMc4dkYbAN56KA5`), not actual secrets. These IDs are used during promote and seed operations to swap credential references between dev and prod environments. Actual credential secrets (API keys, tokens, passwords) are stored in n8n's encrypted credential vault and are never exposed in this framework.
+
+`project.json` is **gitignored by default** (`n8n-sdlc/.gitignore`), so credential IDs are not committed to version control. Do not remove this gitignore entry. For shared team repos where `project.json` is intentionally committed, the credential IDs are safe to share since they carry no authentication value outside of the n8n instance.
+
+### What Is and Is Not Committed
+
+| File | Committed | Contains |
+|------|-----------|----------|
+| `project.json` | No (gitignored) | Credential reference IDs, project config |
+| `project.json.template` | Yes | Example placeholders only |
+| `id-mappings.json` | No (gitignored) | Workflow ID pairs |
+| `secrets.json` | No (gitignored) | Reserved for future use |
+| Workflow JSON files | Yes | Credential type and ID references (not secrets) |
+| MCP config | No (local) | API keys (never commit) |


### PR DESCRIPTION
## Summary
- Added security notes to `project.schema.json` and `project.json.template` explaining that credential IDs are opaque n8n-internal reference IDs, not secrets
- Expanded the Security Notes section in `Team-Onboarding.md` with detailed explanation of what is and isn't committed to git
- `project.json` was already gitignored — this change documents that clearly

Closes #3

## Test plan
- [ ] Markdown lint passes (`npx markdownlint-cli2 "**/*.md"`)
- [ ] JSON schema and template parse without errors
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)