### PR TITLE
fix: add reservedSlots cleanup to reserve skill

### DIFF
--- a/.cursor/skills/n8n-sdlc-reserve-workflows/SKILL.md
+++ b/.cursor/skills/n8n-sdlc-reserve-workflows/SKILL.md
@@ -279,6 +279,12 @@ For `localPath`:
 
 Read `folderStrategy` from `n8n-sdlc/config/project.json`.
 
+## Step 5.5: Clean Up reservedSlots
+
+After claiming, remove stale entries from `reservedSlots` in `id-mappings.json`. For each entry in `reservedSlots`, check if its `id` now appears as any workflow's `dev.id` or `prod.id`. If it does, remove the entry — it has been claimed and is no longer a reserved slot.
+
+If all entries were claimed, set `reservedSlots` to an empty array `[]`.
+
 ## Step 6: Rename Workflows in n8n
 
 Use MCP to update workflow names:


### PR DESCRIPTION
## Summary

- Adds Step 5.5 to the reserve skill that removes claimed entries from `reservedSlots` after slots are assigned to workflows
- Prevents stale entries from accumulating in `id-mappings.json`

Closes #8

## Test plan

- [ ] `npx markdownlint-cli2 "**/*.md"` passes
- [ ] Read updated reserve skill — cleanup step fits naturally between Step 5 and Step 6
- [ ] Verify doctor skill Category 7 (Slot Hygiene) aligns with this cleanup logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)